### PR TITLE
fix install on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ matrix:
   include:
    - os: linux
      arch: amd64
+   - os: osx

--- a/bin/install
+++ b/bin/install
@@ -21,7 +21,7 @@ install_tool() {
     download_path="${tmp_download_dir}/${binary_name}"
 
     echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"
-    curl -sSL -o "${download_path}" "${download_url}"
+    curl -fsSL -o "${download_path}" "${download_url}"
 
     echo "Creating bin directory"
     mkdir -p "${bin_install_path}"
@@ -55,6 +55,10 @@ get_filename() {
     local binary_name="$1"
     local platform="$2"
     local arch_name="$3"
+
+    case $platform in
+        darwin | windows) binary_name="${binary_name}-alpha";;
+    esac
 
     echo "${binary_name}-${platform}-${arch_name}"
 }


### PR DESCRIPTION
This plugin is currently silently failing on macOS, leaving me with a file with the contents:

`Not Found`

`asdf` believes the install was successful. Looking at the goss releases, I see that they're appending `-alpha` to the file name before the platform for both macOS and Windows currently.

PR changes the following:
- the download will fail when `curl` encounters a 404
- append `-alpha` to the end of the binary name on darwin and windows platforms when downloading
- run tests on osx in Travis

I'm not sure when or if they'll change the binary name.