### PR TITLE
Support install latest version

### DIFF
--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -20,7 +20,7 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1
         with:
           command: goss --version
-          version: v0.3.16
+          version: 0.3.16
   lint:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ goss --version
 goss version v0.3.6
 ```
 
-**Note:** alpha support for macOS/Windows has been available on a trial basis since v0.3.12. This plugin will be downloaded with the keyword "-alpha" as a definite keyword for now. See also) [P-R #1](https://github.com/raimon49/asdf-goss/pull/1)
+**Note:** alpha support for macOS/Windows has been available on a trial basis [since v0.3.12](https://github.com/aelsabbahy/goss/releases/tag/v0.3.12). This plugin will be downloaded with the keyword "-alpha" as a definite keyword for now. See also) [P-R #1](https://github.com/raimon49/asdf-goss/pull/1)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ $ asdf plugin add goss
 
 ```bash
 # Install any version of Goss
-$ asdf install goss v0.3.6
+$ asdf install goss 0.3.6
 
 # Set the version of Goss you want
-$ asdf global goss v0.3.6
+$ asdf global goss 0.3.6
 $ goss --version
 goss version v0.3.6
 ```
+
+**Note:** alpha support for macOS/Windows has been available on a trial basis since v0.3.12. This plugin will be downloaded with the keyword "-alpha" as a definite keyword for now. See also) [P-R #1](https://github.com/raimon49/asdf-goss/pull/1)
 
 ## License
 

--- a/bin/install
+++ b/bin/install
@@ -17,7 +17,7 @@ install_tool() {
 
     platform=$(get_platform)
     arch_name=$(get_arch)
-    download_url=$(get_download_url "${version}" "${platform}" "${binary_name}" "${arch_name}")
+    download_url=$(get_download_url "v${version}" "${platform}" "${binary_name}" "${arch_name}")
     download_path="${tmp_download_dir}/${binary_name}"
 
     echo "Downloading [${binary_name}] from ${download_url} to ${download_path}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -10,19 +10,19 @@ list-all() {
         cmd="${cmd} -H 'Authorization: token ${GITHUB_API_TOKEN}'"
         local releases_path="https://api.github.com/repos/${github_repo}/releases"
         cmd="${cmd} ${releases_path}"
-        versions=$(eval "${cmd}" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions| tr '\n' ' ')
+        versions=$(eval "${cmd}" | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"//;s/\",//' | sort_versions | tr '\n' ' ')
     else
         # Fallback when token is not set
         local tags_path="https://github.com/${github_repo}/tags"
         cmd="${cmd} ${tags_path}"
-        versions=$(eval "${cmd}" | grep -E -o "/${github_repo}/releases/tag/v[0-9].[0-9].[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n -u | tr '\n' ' ')
+        versions=$(eval "${cmd}" | grep -E -o "/${github_repo}/releases/tag/v[0-9].[0-9].[0-9][0-9]?" | awk -F '/' '{ print $6 }' | sort_versions | tr '\n' ' ')
     fi
 
     echo "${versions}"
 }
 
 sort_versions() {
-    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/v//g; s/\n/ /' |
         LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 


### PR DESCRIPTION
Needed to remove `v` from `list-all` script results.

As-is:
```sh
$ asdf list-all goss
v0.1.5
v0.1.6
v0.1.7
v0.1.8
v0.1.9
v0.1.10
v0.2.0
v0.2.1
v0.2.2
v0.2.3
v0.2.4
v0.2.5
v0.2.6
v0.3.0
v0.3.1
v0.3.2
v0.3.3
v0.3.4
v0.3.5
v0.3.6
v0.3.7
v0.3.8
v0.3.9
v0.3.10
v0.3.11
v0.3.12
v0.3.13
v0.3.14
v0.3.15
v0.3.16
```

To-be:
```sh
$ asdf list-all goss
0.1.5
0.1.6
0.1.7
0.1.8
0.1.9
0.1.10
0.2.0
0.2.1
0.2.2
0.2.3
0.2.4
0.2.5
0.2.6
0.3.0
0.3.1
0.3.2
0.3.3
0.3.4
0.3.5
0.3.6
0.3.7
0.3.8
0.3.9
0.3.10
0.3.11
0.3.12
0.3.13
0.3.14
0.3.15
0.3.16
```