### PR TITLE
fix: update goss repository group name

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,7 +3,7 @@
 set -e -o pipefail
 
 list-all() {
-    local github_repo="aelsabbahy/goss"
+    local github_repo="goss-org/goss"
     local cmd="curl -sSL"
     local versions
     if [ -n "${GITHUB_API_TOKEN}" ]; then


### PR DESCRIPTION
Hello!

The goss group name has changed from ``aelsabbahy`` to ``goss-org``, so the version could not be obtained.

```
$ ./bin/list-all
$ vi bin/list-all
$ git diff
diff --git a/bin/list-all b/bin/list-all
index fb7c2e2..9904c80 100755
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,7 +3,7 @@
 set -e -o pipefail

 list-all() {
-    local github_repo="aelsabbahy/goss"
+    local github_repo="goss-org/goss"
     local cmd="curl -sSL"
     local versions
     if [ -n "${GITHUB_API_TOKEN}" ]; then
$ ./bin/list-all
0.3.12 0.3.13 0.3.14 0.3.15 0.3.16 0.3.17 0.3.18 0.3.19 0.3.20 0.3.21
$
```