### PR TITLE
Migrate install step from Linuxbrew to apt

### DIFF
--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install shellcheck
-        run: brew install shellcheck
+        run: apt install shellcheck
 
       - name: Run ShellCheck
         run: make test

--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install shellcheck
-         run: |
+        run: |
           sudo apt-get update
           sudo apt-get install shellcheck
 

--- a/.github/workflows/asdf.yml
+++ b/.github/workflows/asdf.yml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install shellcheck
-        run: apt install shellcheck
+         run: |
+          sudo apt-get update
+          sudo apt-get install shellcheck
 
       - name: Run ShellCheck
         run: make test


### PR DESCRIPTION
Actions log:

```bash
Run brew install shellcheck
  brew install shellcheck
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/7576e5d7-a39f-463a-8000-e15de43d91bf.sh: line 1: brew: command not found
Error: Process completed with exit code 127.
```