### PR TITLE
support arm64 for macOS

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -48,6 +48,8 @@ get_arch() {
         arch="amd64"
     elif [ "$(uname -m)" = "aarch64" ]; then
         arch="arm"
+    elif [ "$(uname -m)" = "arm64" ]; then
+        arch="arm64"
     else
         arch="386"
     fi


### PR DESCRIPTION
Hi.
On macOS(with M1 Pro CPU), I cannot install because `uname -m` returns `arm64`.
```
[naosuke@Canopus()] ~
(*'-') < uname -a
Darwin Canopus.local 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep 15 14:43:05 PDT 2023; root:xnu-10002.1.13~1/RELEASE_ARM64_T6020 arm64

[naosuke@Canopus()] ~
(*'-') < uname -m
arm64
```

So, I implemented to support this. 
And, I can install latest binary on my env.
```
[naosuke@Canopus()] ~/.asdf/plugins/goss support_arm64_architecture[]
(*'-') < asdf install goss 0.4.2
Downloading [goss] from https://github.com/goss-org/goss/releases/download/v0.4.2/goss-darwin-arm64 to /var/folders/fm/7wvzg8h906jczw4jsk_nq4rw0000gq/T/asdf_eMLdwD98/goss
Creating bin directory
Cleaning previous binaries
Copying binary

[naosuke@Canopus()] ~/.asdf/plugins/goss support_arm64_architecture[]
(*'-') < asdf global goss 0.4.2

[naosuke@Canopus()] ~/.asdf/plugins/goss support_arm64_architecture[]
(*'-') < goss -v
goss version v0.4.2
```
